### PR TITLE
migasfree.conf with "Server = servidor:443", curl need https protocol

### DIFF
--- a/usr/bin/migasfree-play
+++ b/usr/bin/migasfree-play
@@ -47,6 +47,12 @@ print(get_config(CONF_FILE, 'client').get('server', 'localhost'), end='')
 "
 _SERVER=$($_PYTHON -c "$_SRC")
 
+# server with :443 port need https protocol
+if [[ $_SERVER =~ ":443" ]]
+then
+   _SERVER="https://$_SERVER"
+fi
+
 while true
 do
     _STATUS=$(curl --write-out %{http_code} --silent --output /dev/null "$_SERVER") || :


### PR DESCRIPTION
Cuando curl intenta conectar contra servidor:443 sin protocolo obtiene un error 400 The plain HTTP request was sent to HTTPS port

Para solucionarlo le añadimos en schema https:// a la variable _SERVER