### PR TITLE
Fix rendering apps, possibly wrong "marked" call

### DIFF
--- a/usr/share/migasfree-play/app/app.js
+++ b/usr/share/migasfree-play/app/app.js
@@ -811,6 +811,19 @@ function renderRating(score) {
     return rating;
 }
 
+function tryAny() {
+    for (let i = 0; i < arguments.length; i++){
+        let ret
+        try{
+            ret = arguments[i]()
+            return ret
+        }catch(err){
+            // pass
+        }
+    }
+    return undefined
+}
+
 function renderApp(item) {
     const fs = require("fs");
     const marked = require("marked");
@@ -847,7 +860,14 @@ function renderApp(item) {
         name: item.name,
         idaction: "action-" + slugify(item.name),
         icon: item.icon,
-        description: marked(item.description, {renderer: renderer}),
+        description: tryAny(
+            (function(){
+                return marked(item.description, {renderer: renderer})
+            }),
+            (function(){
+                return marked.parse(item.description, {renderer: renderer})
+            })
+        ),
         truncated: truncatedDesc,
         category: item.category.name,
         rating: renderRating(item.score),


### PR DESCRIPTION
Using migasfree-play on my system it was unable to render available and configured applications on client.
It try to call marked() getting error, i believe that marked.parse() should be used instead to avoid error.
Patch try to use original call (possibly with older marked version) if fails, try to call next function.